### PR TITLE
Add option to flip and append polygons to make them visible from both sides

### DIFF
--- a/yamaopt/visualizer.py
+++ b/yamaopt/visualizer.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import numpy as np
 import time
@@ -39,12 +40,21 @@ class VisManager:
         vertices = np.array(vertices)
         return vertices, faces
 
-    def add_polygon(self, np_polygon):
-        V, F = self._convert_polygon_to_mesh(np_polygon)
-        mesh = visual_mesh=trimesh.Trimesh(
-                vertices=V, faces=F, face_colors=[255, 0, 0, 200])
-        polygon_link = MeshLink(mesh)
-        self.viewer.add(polygon_link)
+    def add_polygon(self, np_polygon, flip_and_append=True):
+        if flip_and_append:
+            # Currently, polygons are only visible from one side
+            # Flip and append the polygon so that it is visible from both sides
+            np_polygon_mirror = copy.deepcopy(np_polygon)
+            np_polygon_mirror = np_polygon_mirror[::-1]
+            np_polygon = [np_polygon, np_polygon_mirror]
+        else:
+            np_polygon = [np_polygon]
+        for p in np_polygon:
+            V, F = self._convert_polygon_to_mesh(p)
+            mesh = visual_mesh=trimesh.Trimesh(
+                    vertices=V, faces=F, face_colors=[255, 0, 0, 200])
+            polygon_link = MeshLink(mesh)
+            self.viewer.add(polygon_link)
 
     def add_polygon_list(self, np_polygon_list):
         for np_polygon in np_polygon_list:


### PR DESCRIPTION
I am sorry, but I changed the default yamaopt behavior to make polygons visible from both sides.

I am still wondering why the polygons are visible from only one side...

```
python example_multi.py -robot pr2 --visualize
```

![Screenshot 2021-12-27 01:12:47](https://user-images.githubusercontent.com/19769486/147413912-ea126509-71ff-4940-9c1a-0b07f61859f0.png)
