### PR TITLE
Tighten joint limit

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -9,6 +9,7 @@ if __name__=='__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-robot', type=str, default='pr2', help='robot name')
     parser.add_argument('-hover', type=float, default='0.05', help='hover distance')
+    parser.add_argument('-margin', type=float, default='5.0', help='joint limit margin [deg]')
     parser.add_argument('--visualize', action='store_true', help='visualize')
     parser.add_argument('--use_base', action='store_true', help='with base')
     args = parser.parse_args()
@@ -16,6 +17,7 @@ if __name__=='__main__':
     visualize = args.visualize
     use_base = args.use_base
     d_hover = args.hover
+    joint_limit_margin = args.margin
 
     if robot_name == 'fetch':
         config_path = "../config/fetch_conf.yaml"
@@ -33,7 +35,8 @@ if __name__=='__main__':
     target_pos = np.array([-0.3, -0.6, 1.6])
 
     q_init = -np.ones(len(kinsol.control_joint_ids)) * 0.4
-    sol = kinsol.solve(q_init, polygon, target_pos, d_hover=d_hover)
+    sol = kinsol.solve(q_init, polygon, target_pos, 
+            d_hover=d_hover, joint_limit_margin=joint_limit_margin)
     assert sol.success
 
     if visualize:

--- a/example/example_multi.py
+++ b/example/example_multi.py
@@ -11,6 +11,7 @@ if __name__=='__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('-robot', type=str, default='pr2', help='robot name')
     parser.add_argument('-hover', type=float, default='0.05', help='hover distance')
+    parser.add_argument('-margin', type=float, default='5.0', help='joint limit margin [deg]')
     parser.add_argument('--visualize', action='store_true', help='visualize')
     parser.add_argument('--use_base', action='store_true', help='with base')
     args = parser.parse_args()
@@ -18,6 +19,7 @@ if __name__=='__main__':
     visualize = args.visualize
     use_base = args.use_base
     d_hover = args.hover
+    joint_limit_margin = args.margin
 
     if robot_name == 'fetch':
         config_path = "../config/fetch_conf.yaml"
@@ -38,7 +40,8 @@ if __name__=='__main__':
     target_obj_pos = np.array([-0.1, 0.7, 0.3])
 
     q_init = -np.ones(len(kinsol.control_joint_ids)) * 0.4
-    sol, target_polygon = kinsol.solve_multiple(q_init, polygons, target_obj_pos, d_hover=d_hover)
+    sol, target_polygon = kinsol.solve_multiple(q_init, polygons, target_obj_pos, 
+            d_hover=d_hover, joint_limit_margin=joint_limit_margin)
     assert sol.success
 
     if visualize:

--- a/yamaopt/solver.py
+++ b/yamaopt/solver.py
@@ -1,9 +1,16 @@
 import os
+import math
+import copy
 import attr
 from tinyfk import RobotModel
 import yaml
 import numpy as np
 import scipy.optimize
+import skrobot
+from skrobot.model.joint import RotationalJoint
+from skrobot.model.joint import FixedJoint
+from skrobot.model.joint import LinearJoint
+from skrobot.model.joint import OmniWheelJoint
 
 from yamaopt.polygon_constraint import polygon_to_trans_constraint
 from yamaopt.polygon_constraint import polygon_to_desired_rpy
@@ -19,27 +26,41 @@ class SolverConfig(object):
     endeffector_link_name = attr.ib()
 
     @classmethod
-    def from_config_path(cls, config_path, use_base=False):
+    def from_config_path(cls, 
+            config_path, 
+            use_base=False, 
+            joint_limit_margin=None # [degree] or None
+            ):
         with open(config_path, 'r') as f:
             cfg = yaml.safe_load(f)
+
         return cls(
                 use_base,
                 urdf_path = cfg['urdf_path'],
                 optimization_frame = cfg['optimization_frame'],
                 control_joint_names = cfg['control_joint_names'],
-                endeffector_link_name = cfg['endeffector_link_name'])
+                endeffector_link_name = cfg['endeffector_link_name'],
+                )
 
 class KinematicSolver:
     def __init__(self, config):
         urdf_path = os.path.expanduser(config.urdf_path)
         self.kin = RobotModel(urdf_path)
 
+        robot_model = skrobot.model.RobotModel() # Here this model is used only for obtaining joint type (as an urdf parser)
+        robot_model.load_urdf_file(urdf_path)
+
         self.config = config
         self.control_joint_ids = self.kin.get_joint_ids(config.control_joint_names)
         joint_limits = self.kin.get_joint_limits(self.control_joint_ids)
+        joint_types = [type(robot_model.__dict__[jn]) for jn in config.control_joint_names]
+
         if self.config.use_base:
             joint_limits.extend([[None, None]] * 3) # for x, y, theta
+            joint_types.extend([LinearJoint, LinearJoint, RotationalJoint])
+
         self.joint_limits = joint_limits
+        self.joint_types = joint_types
         self.end_effector_id = self.kin.get_link_ids([config.endeffector_link_name])[0]
 
     @property
@@ -97,7 +118,7 @@ class KinematicSolver:
 
         return ineq_constraint, eq_constraint
 
-    def solve(self, q_init, np_polygon, target_obs_pos, d_hover=0.0):
+    def solve(self, q_init, np_polygon, target_obs_pos, d_hover=0.0, joint_limit_margin=0.0):
         if self.config.use_base:
             q_init = np.hstack((q_init, np.zeros(3)))
         assert len(q_init) == self.dof
@@ -115,9 +136,21 @@ class KinematicSolver:
 
         f, jac = scipinize(f_obj)
 
+        joint_limits_tight = copy.deepcopy(self.joint_limits)
+        margin = joint_limit_margin * math.pi / 180.0
+        for i in range(len(joint_limits_tight)):
+            joint_type = self.joint_types[i]
+            if joint_type == LinearJoint:
+                continue
+
+            is_infinite_rotational_joint = (None in joint_limits_tight[i])
+            if not is_infinite_rotational_joint:
+                joint_limits_tight[i][0] += margin # tighten lower bound
+                joint_limits_tight[i][1] -= margin # tighten upper bound
+
         res = scipy.optimize.minimize(
             f, q_init, method='SLSQP', jac=jac,
-            constraints=[eq_dict, ineq_dict], bounds=self.joint_limits)
+            constraints=[eq_dict, ineq_dict], bounds=joint_limits_tight)
 
         """
         if output_gif:

--- a/yamaopt/solver.py
+++ b/yamaopt/solver.py
@@ -164,7 +164,7 @@ class KinematicSolver:
 
         return res
 
-    def solve_multiple(self, q_init, np_polygons, target_obs_pos, d_hover=0.0):
+    def solve_multiple(self, q_init, np_polygons, target_obs_pos, d_hover=0.0, joint_limit_margin=0.0):
         """
         np_polygons: List[np.ndarray]
         """
@@ -174,7 +174,7 @@ class KinematicSolver:
         for np_polygon in np_polygons:
             try:
                 sol = self.solve(
-                    q_init, np_polygon, target_obs_pos, d_hover=d_hover)
+                    q_init, np_polygon, target_obs_pos, d_hover=d_hover, joint_limit_margin=joint_limit_margin)
                 if sol.success and sol.fun < min_cost:
                     min_cost = sol.fun
                     min_sol = sol


### PR DESCRIPTION
## Tighten joint limit. 
Unlike ordinary inverse kinematics that uses singular robust (SR) inverse, this software sorely relies on the SQP optimization. Therefore the obtained solution's joint angles tend to be near or equal to the boundary of the inequality constraints, which means joint angle tends to its boundary. (From my experience, this kind of solution occurs typically when use_base is True)
This kind of near-boundary solution is problematic when you consider a next action, because near-boundary joint angle configuration has only tiny null-space. So, as a workaround, I added joint limit tightning procedure when initializing the solver. 

*Note* that this tightning is omitted for linear joint (like torso joint) 

## Experiment
When set joint_limit_margin=0.0, joint hit joint limit (stack at singular pose)
<img src="https://user-images.githubusercontent.com/38597814/147604900-2919ce5f-3808-429f-9df5-371b9ec0d73c.png" width="400px">
but with joint_limit_maring=20.0, solution is improved: 
<img src="https://user-images.githubusercontent.com/38597814/147604903-5cdaaa83-6f4c-4c39-9e51-b7753a909193.png" width="400px">


```python
#!/usr/bin/env python
import argparse
import math
import numpy as np
import pickle
from skrobot.coordinates.math import rotation_matrix
from yamaopt.solver import KinematicSolver, SolverConfig
from yamaopt.polygon_constraint import polygon_to_trans_constraint
from yamaopt.visualizer import VisManager

if __name__=='__main__':
    parser = argparse.ArgumentParser()
    parser.add_argument('-robot', type=str, default='pr2', help='robot name')
    parser.add_argument('-hover', type=float, default='0.05', help='hover distance')
    parser.add_argument('--visualize', action='store_true', help='visualize')
    parser.add_argument('--use_base', action='store_true', help='with base')
    args = parser.parse_args()
    robot_name = args.robot
    visualize = args.visualize
    use_base = args.use_base
    d_hover = args.hover

    if robot_name == 'fetch':
        config_path = "../config/fetch_conf.yaml"
    elif robot_name == 'pr2':
        config_path = "../config/pr2_conf.yaml"
    else:
        raise Exception()

    config = SolverConfig.from_config_path(config_path, use_base=use_base)
    kinsol = KinematicSolver(config)

    with open('/home/h-ishida/Downloads/case2.pickle', 'rb') as f:
    # with open('/home/leus/Downloads/case2.pickle', 'rb') as f:
        polygons = pickle.load(f, encoding='latin1')
    target_obj_pos = np.array([1.0, 0.3, 1.0])

    q_init = -np.ones(len(kinsol.control_joint_ids)) * 0.4
    sol, _ = kinsol.solve_multiple(q_init, polygons, target_obj_pos, d_hover=d_hover, joint_limit_margin=0)
    assert sol.success

    if visualize:
        # visualize
        vm = VisManager(config)
        vm.add_polygon_list(polygons)
        vm.add_target(target_obj_pos)
        vm.set_angle_vector(sol.x)
        vm.show_while()
```
