### PR TITLE
Install numpy>=1.16.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup_requires = []
 
 install_requires = [
-        "numpy",
+        "numpy>=1.16.6",
         "attrs",
         # https://github.com/HiroIshida/yamaopt/issues/18#issuecomment-1002915454
         "scipy>=1.2.0",


### PR DESCRIPTION
Install numpy>=1.16.6

When I use yamaopt with `ros-industrial/industrial_ci`, default numpy(==1.13.3) is used.
https://github.com/708yamaguchi/yamaopt_ros/runs/4679899814?check_suite_focus=true

This causes error in `np.flip()`
Previously, `np.flip()` takes 2 arguments, but now it takes 1 arguments.
https://numpy.org/doc/1.13/reference/generated/numpy.flip.html?highlight=flip#numpy.flip
https://numpy.org/doc/1.16/reference/generated/numpy.flip.html?highlight=flip#numpy.flip


