### PR TITLE
Move try-except to solve() from solve_multiple() to catch exception in solve()

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,10 +44,12 @@ jobs:
             - name: Run example
               run: |
                   cd example
-                  # Check robot options and use_base options
+                  # Check robot, use_base, limit_base options
                   python example.py -robot pr2
                   python example.py -robot fetch
                   python example.py -robot pr2 --use_base
                   python example.py -robot fetch --use_base
+                  python example.py -robot pr2 --use_base --limit_base
+                  python example.py -robot fetch --use_base --limit_base
                   # Check concave polygon input
                   python example_multi.py -robot pr2

--- a/example/example.py
+++ b/example/example.py
@@ -46,7 +46,11 @@ if __name__=='__main__':
     sol = kinsol.solve(q_init, polygon, target_pos,
                        movable_polygon=movable_polygon,
                        d_hover=d_hover, joint_limit_margin=joint_limit_margin)
-    assert sol.success
+    if sol.success:
+        print('optimization succeeded.')
+    else:
+        print('optimization failed.')
+        assert sol.success
 
     if visualize:
         # visualize

--- a/example/example.py
+++ b/example/example.py
@@ -34,9 +34,16 @@ if __name__=='__main__':
     polygon += np.array([0.3, -0.7, 0.7])
     target_pos = np.array([-0.3, -0.6, 1.6])
 
+    movable_polygon = np.array(
+        [[0.5, 0, 0], [0, 0.5, 0], [-0.5, 0, 0], [0, -0.5, 0]])
+    movable_polygon += np.array([-1.0, -1.0, 0.0])
+    if not config.use_base:
+        movable_polygon = None
+
     q_init = -np.ones(len(kinsol.control_joint_ids)) * 0.4
-    sol = kinsol.solve(q_init, polygon, target_pos, 
-            d_hover=d_hover, joint_limit_margin=joint_limit_margin)
+    sol = kinsol.solve(q_init, polygon, target_pos,
+                       movable_polygon=movable_polygon,
+                       d_hover=d_hover, joint_limit_margin=joint_limit_margin)
     assert sol.success
 
     if visualize:

--- a/example/example.py
+++ b/example/example.py
@@ -12,12 +12,14 @@ if __name__=='__main__':
     parser.add_argument('-margin', type=float, default='5.0', help='joint limit margin [deg]')
     parser.add_argument('--visualize', action='store_true', help='visualize')
     parser.add_argument('--use_base', action='store_true', help='with base')
+    parser.add_argument('--limit_base', action='store_true', help='limit movable area of base')
     args = parser.parse_args()
     robot_name = args.robot
     visualize = args.visualize
     use_base = args.use_base
     d_hover = args.hover
     joint_limit_margin = args.margin
+    limit_base = args.limit_base
 
     if robot_name == 'fetch':
         config_path = "../config/fetch_conf.yaml"
@@ -26,7 +28,6 @@ if __name__=='__main__':
     else:
         raise Exception()
 
-
     config = SolverConfig.from_config_path(config_path, use_base=use_base)
     kinsol = KinematicSolver(config)
 
@@ -34,10 +35,11 @@ if __name__=='__main__':
     polygon += np.array([0.3, -0.7, 0.7])
     target_pos = np.array([-0.3, -0.6, 1.6])
 
-    movable_polygon = np.array(
-        [[0.5, 0, 0], [0, 0.5, 0], [-0.5, 0, 0], [0, -0.5, 0]])
-    movable_polygon += np.array([-1.0, -1.0, 0.0])
-    if not config.use_base:
+    if use_base and limit_base:
+        movable_polygon = np.array(
+            [[0.5, 0, 0], [0, 0.5, 0], [-0.5, 0, 0], [0, -0.5, 0]])
+        movable_polygon += np.array([-1.0, -1.0, 0.0])
+    else:
         movable_polygon = None
 
     q_init = -np.ones(len(kinsol.control_joint_ids)) * 0.4

--- a/example/example.py
+++ b/example/example.py
@@ -50,5 +50,6 @@ if __name__=='__main__':
         # visualize
         vm = VisManager(config)
         vm.add_target(target_pos)
-        vm.reflect_solver_result(sol, [polygon], show_polygon_axis=True)
+        vm.reflect_solver_result(sol, [polygon], movable_polygon,
+                                 show_polygon_axis=True)
         vm.show_while()

--- a/example/example_multi.py
+++ b/example/example_multi.py
@@ -37,11 +37,19 @@ if __name__=='__main__':
     polygon3 = polygon1.dot(rotation_matrix(-math.pi / 2.0, [0, 0, 1.0]).T)
     polygon4 = np.array([[1.0, 0.2, 0.2], [1.0, 0.5, -0.5], [1.0, 0.5, 0.5], [1.0, -0.5, 0.5]]) + np.array([0, 0, 1.0])
     polygons = [polygon1, polygon2, polygon3, polygon4]
+
     target_obj_pos = np.array([-0.1, 0.7, 0.3])
+    movable_polygon = np.array(
+        [[0.5, 0, 0], [0, 0.5, 0], [-0.5, 0, 0], [0, -0.5, 0]])
+    movable_polygon += np.array([-1.4, 0.5, 0.0])
+    if not config.use_base:
+        movable_polygon = None
 
     q_init = -np.ones(len(kinsol.control_joint_ids)) * 0.4
-    sol = kinsol.solve_multiple(q_init, polygons, target_obj_pos, 
-                                d_hover=d_hover, joint_limit_margin=joint_limit_margin)
+    sol = kinsol.solve_multiple(q_init, polygons, target_obj_pos,
+                                movable_polygon=movable_polygon,
+                                d_hover=d_hover,
+                                joint_limit_margin=joint_limit_margin)
     assert sol.success
 
     if visualize:

--- a/example/example_multi.py
+++ b/example/example_multi.py
@@ -14,12 +14,14 @@ if __name__=='__main__':
     parser.add_argument('-margin', type=float, default='5.0', help='joint limit margin [deg]')
     parser.add_argument('--visualize', action='store_true', help='visualize')
     parser.add_argument('--use_base', action='store_true', help='with base')
+    parser.add_argument('--limit_base', action='store_true', help='limit movable area of base')
     args = parser.parse_args()
     robot_name = args.robot
     visualize = args.visualize
     use_base = args.use_base
     d_hover = args.hover
     joint_limit_margin = args.margin
+    limit_base = args.limit_base
 
     if robot_name == 'fetch':
         config_path = "../config/fetch_conf.yaml"
@@ -27,7 +29,6 @@ if __name__=='__main__':
         config_path = "../config/pr2_conf.yaml"
     else:
         raise Exception()
-
 
     config = SolverConfig.from_config_path(config_path, use_base=use_base)
     kinsol = KinematicSolver(config)
@@ -39,10 +40,12 @@ if __name__=='__main__':
     polygons = [polygon1, polygon2, polygon3, polygon4]
 
     target_obj_pos = np.array([-0.1, 0.7, 0.3])
-    movable_polygon = np.array(
-        [[0.5, 0, 0], [0, 0.5, 0], [-0.5, 0, 0], [0, -0.5, 0]])
-    movable_polygon += np.array([-1.4, 0.5, 0.0])
-    if not config.use_base:
+
+    if use_base and limit_base:
+        movable_polygon = np.array(
+            [[0.5, 0, 0], [0, 0.5, 0], [-0.5, 0, 0], [0, -0.5, 0]])
+        movable_polygon += np.array([-1.4, 0.5, 0.0])
+    else:
         movable_polygon = None
 
     q_init = -np.ones(len(kinsol.control_joint_ids)) * 0.4

--- a/example/example_multi.py
+++ b/example/example_multi.py
@@ -53,7 +53,11 @@ if __name__=='__main__':
                                 movable_polygon=movable_polygon,
                                 d_hover=d_hover,
                                 joint_limit_margin=joint_limit_margin)
-    assert sol.success
+    if sol.success:
+        print('optimization succeeded.')
+    else:
+        print('optimization failed.')
+        assert sol.success
 
     if visualize:
         # visualize

--- a/example/example_multi.py
+++ b/example/example_multi.py
@@ -56,5 +56,7 @@ if __name__=='__main__':
         # visualize
         vm = VisManager(config)
         vm.add_target(target_obj_pos)
-        vm.reflect_solver_result(sol, polygons, show_polygon_axis=True)
+        vm.reflect_solver_result(
+            sol, polygons, movable_polygon=movable_polygon,
+            show_polygon_axis=True)
         vm.show_while()

--- a/yamaopt/polygon_constraint.py
+++ b/yamaopt/polygon_constraint.py
@@ -23,6 +23,10 @@ class ConcavePolygonException(Exception):
     """Raised when the polygon is concave (not convex)"""
     pass
 
+class ZValueNotZeroException(Exception):
+    """Raised when the polygon's z value is not 0"""
+    pass
+
 def check_convexity_and_maybe_ammend(np_polygon):
     # TODO(HiroIshida) PR to jsk_pcl_ros
     # to circumvent jsk_pcl_ros's bag. Ad-hoc fix to convert non-convex to convex

--- a/yamaopt/visualizer.py
+++ b/yamaopt/visualizer.py
@@ -78,7 +78,8 @@ class VisManager:
         self.viewer.add(target_sphere_link)
 
     def reflect_solver_result(
-            self, solver_result, np_polygon_list, show_polygon_axis=False):
+            self, solver_result, np_polygon_list, movable_polygon=None,
+            show_polygon_axis=False):
         # change visual robot configuration
         self.set_angle_vector(solver_result.x)
 
@@ -104,6 +105,11 @@ class VisManager:
         self.add_polygon(
             solver_result.target_polygon,
             rgba=[0, 255, 0, 255], show_axis=show_polygon_axis)
+
+        # add polygon where robot can move
+        if movable_polygon is not None:
+            self.add_polygon(
+                movable_polygon, rgba=[0, 255, 255, 255], show_axis=False)
 
     def set_angle_vector(self, q):
         joints = [self.robot.__dict__[name] for name in self.config.control_joint_names]


### PR DESCRIPTION
Merge after https://github.com/HiroIshida/yamaopt/pull/29

This PR and https://github.com/HiroIshida/yamaopt/pull/29 is independent.
But I create this PR depending on https://github.com/HiroIshida/yamaopt/pull/29 to avoid conflict.

I move
```
try:
...
except ConcavePolygonException:
...
except ZValueNotZeroException:
...
```
from `solve_multiple()` to `solve()`.

Without this change, we cannot catch the exceptions in `solve()`.