### PR TITLE
Add package information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,10 @@ install_requires = [
 setup(
     name='yamaopt',
     version='0.0.1',
-    description='',
+    description='Optimizing the position where the robot attaches the sensor.',
+    author='Hirokazu Ishida',
+    author_email='h-ishida@jsk.imi.i.u-tokyo.ac.jp',
+    url='https://github.com/HiroIshida/yamaopt',
     license='MIT',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I add package information like author and home page.

Before:
```
$ pip show yamaopt
Name: yamaopt
Version: 0.0.1
Summary: UNKNOWN
Home-page: UNKNOWN
Author: UNKNOWN
Author-email: UNKNOWN
License: MIT
Location: /home/leus/yamaopt_ws/src/yamaopt_ros/yamaopt
Requires: numpy, attrs, scipy, tinyfk, scikit-robot
Required-by:
```

After:
```
$ pip show yamaopt
Name: yamaopt
Version: 0.0.1
Summary: Optimizing the position where the robot attaches the sensor.
Home-page: https://github.com/HiroIshida/yamaopt
Author: Hirokazu Ishida
Author-email: h-ishida@jsk.imi.i.u-tokyo.ac.jp
License: MIT
Location: /home/leus/yamaopt_ws/src/yamaopt_ros/yamaopt
Requires: numpy, attrs, scipy, tinyfk, scikit-robot
Required-by: 
```