### PR TITLE
Cache desired_rpy

### DIFF
--- a/yamaopt/polygon_constraint.py
+++ b/yamaopt/polygon_constraint.py
@@ -2,6 +2,7 @@ import attr
 import numpy as np
 from skrobot.coordinates.math import matrix2quaternion
 from skrobot.coordinates.math import rpy_angle
+from yamaopt.utils import array_cache
 
 @attr.s # like a dataclass in python3
 class LinearEqConst(object):
@@ -89,6 +90,7 @@ def polygon_to_matrix(np_polygon, normal=None):
     M = np.vstack([x_axis, y_axis, z_axis]).T
     return M, x_flip
 
+@array_cache
 def polygon_to_desired_rpy(np_polygon, normal=None):
     M, _ = polygon_to_matrix(np_polygon, normal)
     ypr = rpy_angle(M)[0]


### PR DESCRIPTION
About 2x faster by this PR
Before 
```
h-ishida@stonet4:~/python/yamaopt/example$ python3 example_multi.py -robot pr2 --use_base --limit_base
/home/h-ishida/python/scikit-robot/skrobot/model/robot_model.py:1691: UserWarning: texture specified in URDF is not supported
  warnings.warn(
Input polygon is not convex. Skip optimization.

  _     ._   __/__   _ _  _  _ _/_   Recorded: 19:31:21  Samples:  1310
 /_//_/// /_\ / //_// / //_'/ //     Duration: 1.312     CPU time: 1.312
/   _/                      v4.1.1

Program: example_multi.py -robot pr2 --use_base --limit_base

1.312 <module>  example_multi.py:2
└─ 1.312 solve_multiple  yamaopt/solver.py:245
   └─ 1.312 solve  yamaopt/solver.py:177
      └─ 1.308 minimize  scipy/optimize/_minimize.py:42
         └─ 1.308 _minimize_slsqp  scipy/optimize/slsqp.py:215
            ├─ 0.880 <listcomp>  scipy/optimize/slsqp.py:406
            │  └─ 0.868 fun_scipinized  yamaopt/utils.py:25
            │     └─ 0.862 hand_eq_constraint  yamaopt/solver.py:137
            │        ├─ 0.622 polygon_to_desired_rpy  yamaopt/polygon_constraint.py:92
            │        │  ├─ 0.517 polygon_to_matrix  yamaopt/polygon_constraint.py:64
            │        │  │  ├─ 0.309 cross  <__array_function__ internals>:2
            │        │  │  │  └─ 0.295 cross  numpy/core/numeric.py:1417
            │        │  │  │     ├─ 0.153 moveaxis  <__array_function__ internals>:2
            │        │  │  │     │  └─ 0.137 moveaxis  numpy/core/numeric.py:1336
            │        │  │  │     │     ├─ 0.063 normalize_axis_tuple  numpy/core/numeric.py:1273
            │        │  │  │     │     │  └─ 0.042 [self]  
            │        │  │  │     │     └─ 0.044 [self]  
            │        │  │  │     └─ 0.117 [self]  
            │        │  │  ├─ 0.061 mean  <__array_function__ internals>:2
            │        │  │  │  └─ 0.054 mean  numpy/core/fromnumeric.py:3153
            │        │  │  │     └─ 0.045 _mean  numpy/core/_methods.py:134
            │        │  │  │        └─ 0.029 [self]  
            │        │  │  ├─ 0.057 <lambda>  yamaopt/polygon_constraint.py:65
            │        │  │  │  └─ 0.045 norm  <__array_function__ internals>:2
            │        │  │  │     └─ 0.039 norm  numpy/linalg/linalg.py:2325
            │        │  │  │        └─ 0.022 [self]  
            │        │  │  ├─ 0.042 [self]  
            │        │  │  └─ 0.036 vstack  <__array_function__ internals>:2
            │        │  │     └─ 0.028 vstack  numpy/core/shape_base.py:223
            │        │  └─ 0.089 rpy_angle  skrobot/coordinates/math.py:508
            │        │     └─ 0.082 [self]  
            │        ├─ 0.111 delete  <__array_function__ internals>:2
            │        │  └─ 0.103 delete  numpy/lib/function_base.py:4225
            │        │     └─ 0.080 [self]  
            │        ├─ 0.036 forward_kinematics  yamaopt/solver.py:97
            │        │  └─ 0.032 solve_forward_kinematics  tinyfk/__init__.py:51
            │        │     └─ 0.028 [self]  
            │        ├─ 0.031 [self]  
            │        ├─ 0.027 vstack  <__array_function__ internals>:2
            │        │  └─ 0.024 vstack  numpy/core/shape_base.py:223
            │        └─ 0.019 hstack  <__array_function__ internals>:2
            │           └─ 0.016 hstack  numpy/core/shape_base.py:285
            ├─ 0.151 <listcomp>  scipy/optimize/slsqp.py:411
            │  └─ 0.133 fun_scipinized  yamaopt/utils.py:25
            │     ├─ 0.075 hand_ineq_constraint  yamaopt/solver.py:129
            │     │  ├─ 0.042 forward_kinematics  yamaopt/solver.py:97
            │     │  │  └─ 0.036 solve_forward_kinematics  tinyfk/__init__.py:51
            │     │  │     └─ 0.027 [self]  
            │     │  └─ 0.020 [self]  
            │     └─ 0.045 base_ineq_constraint  yamaopt/solver.py:165
            │        └─ 0.024 [self]  
            ├─ 0.140 function_wrapper  scipy/optimize/optimize.py:325
            │  └─ 0.138 fun_scipinized  yamaopt/utils.py:25
            │     └─ 0.132 f  yamaopt/solver.py:113
            │        ├─ 0.042 sum  <__array_function__ internals>:2
            │        │  └─ 0.034 sum  numpy/core/fromnumeric.py:2045
            │        │     └─ 0.031 _wrapreduction  numpy/core/fromnumeric.py:73
            │        │        └─ 0.025 ufunc.reduce  <built-in>:0
            │        ├─ 0.041 forward_kinematics  yamaopt/solver.py:97
            │        │  └─ 0.036 solve_forward_kinematics  tinyfk/__init__.py:51
            │        │     └─ 0.030 [self]  
            │        └─ 0.033 [self]  
            ├─ 0.107 [self]  
            └─ 0.015 concatenate  <__array_function__ internals>:2

```
After
```
h-ishida@stonet4:~/python/yamaopt/example$ python3 example_multi.py -robot pr2 --use_base --limit_base
/home/h-ishida/python/scikit-robot/skrobot/model/robot_model.py:1691: UserWarning: texture specified in URDF is not supported
  warnings.warn(
Input polygon is not convex. Skip optimization.

  _     ._   __/__   _ _  _  _ _/_   Recorded: 21:29:34  Samples:  705
 /_//_/// /_\ / //_// / //_'/ //     Duration: 0.706     CPU time: 0.706
/   _/                      v4.1.1

Program: example_multi.py -robot pr2 --use_base --limit_base

0.706 <module>  example_multi.py:2
└─ 0.706 solve_multiple  yamaopt/solver.py:245
   └─ 0.706 solve  yamaopt/solver.py:177
      └─ 0.702 minimize  scipy/optimize/_minimize.py:42
         └─ 0.702 _minimize_slsqp  scipy/optimize/slsqp.py:215
            ├─ 0.320 <listcomp>  scipy/optimize/slsqp.py:406
            │  ├─ 0.308 fun_scipinized  yamaopt/utils.py:46
            │  │  └─ 0.303 hand_eq_constraint  yamaopt/solver.py:137
            │  │     ├─ 0.108 delete  <__array_function__ internals>:2
            │  │     │  ├─ 0.093 delete  numpy/lib/function_base.py:4225
            │  │     │  │  ├─ 0.066 [self]  
            │  │     │  │  └─ 0.011 asarray  numpy/core/_asarray.py:16
            │  │     │  │     └─ 0.011 array  <built-in>:0
            │  │     │  └─ 0.008 [self]  
            │  │     ├─ 0.055 forward_kinematics  yamaopt/solver.py:97
            │  │     │  └─ 0.049 solve_forward_kinematics  tinyfk/__init__.py:51
            │  │     │     ├─ 0.034 [self]  
            │  │     │     └─ 0.012 array  <built-in>:0
            │  │     ├─ 0.042 hstack  <__array_function__ internals>:2
            │  │     │  └─ 0.034 hstack  numpy/core/shape_base.py:285
            │  │     │     ├─ 0.014 atleast_1d  <__array_function__ internals>:2
            │  │     │     │  └─ 0.010 atleast_1d  numpy/core/shape_base.py:24
            │  │     │     ├─ 0.012 concatenate  <__array_function__ internals>:2
            │  │     │     │  └─ 0.011 implement_array_function  <built-in>:0
            │  │     │     └─ 0.008 [self]  
            │  │     ├─ 0.040 [self]  
            │  │     ├─ 0.023 vstack  <__array_function__ internals>:2
            │  │     │  └─ 0.020 vstack  numpy/core/shape_base.py:223
            │  │     │     └─ 0.010 concatenate  <__array_function__ internals>:2
            │  │     │        └─ 0.008 implement_array_function  <built-in>:0
            │  │     ├─ 0.016 wrapped  yamaopt/utils.py:10
            │  │     ├─ 0.011 ndarray.dot  <built-in>:0
            │  │     └─ 0.008 ndarray.flatten  <built-in>:0
            │  └─ 0.010 atleast_1d  <__array_function__ internals>:2
            ├─ 0.147 <listcomp>  scipy/optimize/slsqp.py:411
            │  ├─ 0.122 fun_scipinized  yamaopt/utils.py:46
            │  │  ├─ 0.080 hand_ineq_constraint  yamaopt/solver.py:129
            │  │  │  ├─ 0.048 forward_kinematics  yamaopt/solver.py:97
            │  │  │  │  ├─ 0.040 solve_forward_kinematics  tinyfk/__init__.py:51
            │  │  │  │  │  ├─ 0.031 [self]  
            │  │  │  │  │  └─ 0.009 array  <built-in>:0
            │  │  │  │  └─ 0.008 [self]  
            │  │  │  ├─ 0.020 [self]  
            │  │  │  └─ 0.009 ndarray.dot  <built-in>:0
            │  │  └─ 0.035 base_ineq_constraint  yamaopt/solver.py:165
            │  │     └─ 0.017 [self]  
            │  ├─ 0.017 atleast_1d  <__array_function__ internals>:2
            │  │  └─ 0.011 atleast_1d  numpy/core/shape_base.py:24
            │  └─ 0.008 [self]  
            ├─ 0.122 function_wrapper  scipy/optimize/optimize.py:325
            │  └─ 0.119 fun_scipinized  yamaopt/utils.py:46
            │     └─ 0.117 f  yamaopt/solver.py:113
            │        ├─ 0.036 forward_kinematics  yamaopt/solver.py:97
            │        │  └─ 0.030 solve_forward_kinematics  tinyfk/__init__.py:51
            │        │     └─ 0.021 [self]  
            │        ├─ 0.036 [self]  
            │        ├─ 0.030 sum  <__array_function__ internals>:2
            │        │  └─ 0.025 sum  numpy/core/fromnumeric.py:2045
            │        │     └─ 0.020 _wrapreduction  numpy/core/fromnumeric.py:73
            │        │        └─ 0.011 ufunc.reduce  <built-in>:0
            │        └─ 0.008 ndarray.flatten  <built-in>:0
            ├─ 0.076 [self]  
            ├─ 0.016 concatenate  <__array_function__ internals>:2
            │  └─ 0.013 implement_array_function  <built-in>:0
            └─ 0.011 vstack  <__array_function__ internals>:2
```