### PR TITLE
Update tinyfk

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,6 @@ For Python2.x, the following apt install is required to install scikit-robot:
 ```
 sudo apt-get install -y libspatialindex-dev freeglut3-dev libsuitesparse-dev libblas-dev liblapack-dev
 ```
-
-If you don't have `GLIBCXX_3.4.26`, install following packages: (for tinyik)
-```
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt update
-sudo apt install gcc-9
-sudo apt install libstdc++6
-```
-
 Then, install yamaopt
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
         "attrs",
         # https://github.com/HiroIshida/yamaopt/issues/18#issuecomment-1002915454
         "scipy>=1.2.0",
-        "tinyfk>=0.4.5",
+        "tinyfk>=0.4.6",
         "scikit-robot>=0.0.15",
         ]
 


### PR DESCRIPTION
From v0.4.6, binary of tinyfk is built on ubuntu16.04 (GLIBCXX_3.4.21) and release automatically on github action. So, tinyfk is compatible with 16.04 ~. 