### PR TITLE
Avoid nan in polygon_to_matrix

### DIFF
--- a/yamaopt/polygon_constraint.py
+++ b/yamaopt/polygon_constraint.py
@@ -81,7 +81,11 @@ def polygon_to_matrix(np_polygon, normal=None):
             x_flip = True
         x_axis = normalize(normal)
     # Calculate y and z axis of polygon
-    y_axis = normalize(strip_z(points[1] - points[0]))
+    p = points[1] - points[0]
+    if p[0] == 0.0 and p[1] == 0.0:
+        y_axis = np.array([0, 0, 1.0])
+    else:
+        y_axis = normalize(strip_z(p))
     z_axis = np.cross(x_axis, y_axis)
     if z_axis[2] < 0.0:
         y_axis *= -1


### PR DESCRIPTION
When y=0 polygon is input,
```
import numpy as np
from yamaopt.polygon_constraint import polygon_to_matrix

a = np.array([[ 0.12625,    -0.1425,      1.01043141],
[ 0.12625,    -0.1425,      1.09043145],
[-0.05375,    -0.1425,      1.09043145],
[-0.05375,    -0.1425,      1.01043141]])
b = np.array([-0., -1., -0.])

polygon_to_matrix(a, b)
```

I got the following result.
```
/home/leus/ws_ws/src/708yamaguchi/yamaopt_ros/yamaopt/yamaopt/polygon_constraint.py:66: RuntimeWarning: invalid value encountered in divide
  normalize = lambda vec: vec/np.linalg.norm(vec)
Out[1]: 
(array([[-0., nan, nan],
        [-1., nan, nan],
        [-0., nan, nan]]), True)
```

I do not have confident in this solution...